### PR TITLE
Remove IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ jdk:
 script: mvn compile test
 install: true
 notifications:
-  irc: 
-    channels: 
-      - "irc.esper.net#drtshock"
-    on_success: change
-    on_failure: always
   email:
     recipients:
       - "drtshock13@gmail.com"


### PR DESCRIPTION
If you're going to further modify this fork further w/ Travis enabled, it'd be great if you could turn off the notifications to avoid build messages in `#drtshock` (the main project is one thing, but every fork sending notifications gets a little unwieldy!).

Thanks